### PR TITLE
score -> log_score

### DIFF
--- a/disco/scorers/exponential_scorer.py
+++ b/disco/scorers/exponential_scorer.py
@@ -54,7 +54,7 @@ class ExponentialScorer(PositiveScorer):
         device = get_device(self.coefficients)
 
         feature_log_scores = torch.stack(
-                ([feature.score(samples, context).to(device) for feature in self.features])
+                ([feature.log_score(samples, context).to(device) for feature in self.features])
             ) # [n_features, n_samples]
         weighted_log_scores = self.coefficients.repeat(len(samples), 1) * feature_log_scores.t()
 


### PR DESCRIPTION
(Sorry if I misunderstood,) it looks like ExponentialScorer.log_score use score, which makes [target_log_scores](https://github.com/naver/disco/blob/957c3fc5f9fc8869f0600978e0a8b092739b1986/disco/tuners/tuner.py#L381C18-L381C18) `a(x)exp(\lambda exp(\phi(x)))`. 