### PR TITLE
Fix/use score for moment estimate

### DIFF
--- a/disco/scorers/pipeline_scorer.py
+++ b/disco/scorers/pipeline_scorer.py
@@ -26,8 +26,8 @@ class PipelineScorer(PositiveScorer):
         self.pipeline = pipeline(**params)
         self.temperature = temperature
 
-    def log_score(self, samples, _):
-        """computes the log-scores of the samples
+    def score(self, samples, _):
+        """computes the scores of the samples
         from the label returned by the pipeline
 
         Parameters
@@ -37,9 +37,9 @@ class PipelineScorer(PositiveScorer):
 
         Returns
         -------
-        tensor of log-probabilities"""
+        tensor of scores"""
 
-        return torch.log(
+        return (
                 torch.tensor(
                     [[r_i["score"] for r_i in r if self.label == r_i["label"]][0]
                     for r in self.pipeline([s.text for s in samples], return_all_scores=True)]

--- a/disco/tuners/tuner.py
+++ b/disco/tuners/tuner.py
@@ -187,7 +187,7 @@ class Tuner():
         logweights = model_log_scores - proposal_log_scores
         importance_ratios = torch.exp(logweights)
         for (label, feature) in self.features:
-            proposal_moment_pointwise_estimates = feature.log_score(samples, context).exp().to(device)
+            proposal_moment_pointwise_estimates = feature.score(samples, context).to(device)
             self.features_moments_proposal[label][context] += proposal_moment_pointwise_estimates
             self.features_moments_target[label][context] += importance_ratios * proposal_moment_pointwise_estimates
 


### PR DESCRIPTION
Define and use `score` by default rather than `log_score`, as some pipeline scorers can have negative scores